### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- add a root .editorconfig with shared defaults for UTF-8, LF, final newline, and 2-space indentation
- add Makefile tab-indentation override
- disable markdown trailing-whitespace trimming to preserve intentional hard line breaks

## Validation
- ran: env -u LOCK_PATH -u TASKS_PATH -u ORCH_HOME just test
- result: existing unrelated test failures in the current branch; no failures caused by .editorconfig changes

## Related
- configuration task for adding .editorconfig