### PR TITLE
chore: add .editorconfig standard indentation rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*.{sh,bash,zsh}]
+indent_style = space
+indent_size = 2
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{md,markdown}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
## Summary
- add root .editorconfig
- enforce indent_style = space and indent_size = 2 for shell, YAML, and Markdown files

## Related
Closes #18