### PR TITLE
fix: add shellcheck directives for scripts sourcing lib.sh

### DIFF
--- a/scripts/dashboard.sh
+++ b/scripts/dashboard.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=scripts/lib.sh
 set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 source "$(dirname "$0")/output.sh"

--- a/scripts/jobs_tick.sh
+++ b/scripts/jobs_tick.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=scripts/lib.sh
 set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 require_yq

--- a/scripts/poll.sh
+++ b/scripts/poll.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=scripts/lib.sh
 set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 require_yq

--- a/scripts/route_task.sh
+++ b/scripts/route_task.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=scripts/lib.sh
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source "$SCRIPT_DIR/lib.sh"

--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck source=scripts/lib.sh
 set -euo pipefail
 SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
 source "$SCRIPT_DIR/lib.sh"


### PR DESCRIPTION
## Summary
- add `# shellcheck source=scripts/lib.sh` to scripts that source `lib.sh`
- keep changes as one-line additions only

## Files
- scripts/run_task.sh
- scripts/route_task.sh
- scripts/poll.sh
- scripts/jobs_tick.sh
- scripts/dashboard.sh

## Testing
- `bash -n scripts/run_task.sh scripts/route_task.sh scripts/poll.sh scripts/jobs_tick.sh scripts/dashboard.sh`
- `env -u LOCK_PATH just test` *(fails on pre-existing unrelated tests in `run_task.sh`/E2E paths)*
