### PR TITLE
fix: disable bash jobs with missing dir

### DIFF
--- a/scripts/jobs_tick.sh
+++ b/scripts/jobs_tick.sh
@@ -82,6 +82,15 @@ for i in $(seq 0 $((JOB_COUNT - 1))); do
       continue
     fi
 
+    if [ -n "$JOB_DIR" ] && [ "$JOB_DIR" != "null" ] && [ ! -d "$JOB_DIR" ]; then
+      job_log "[jobs] job=$JOB_ID invalid dir=$JOB_DIR, disabling job to prevent repeated failures"
+      NOW=$(now_iso)
+      BASH_STATUS="failed"
+      export NOW BASH_STATUS
+      yq -i ".jobs[$i].enabled = false | .jobs[$i].last_run = strenv(NOW) | .jobs[$i].last_task_status = strenv(BASH_STATUS)" "$JOBS_PATH"
+      continue
+    fi
+
     job_log "[jobs] job=$JOB_ID running bash command"
     BASH_RC=0
     BASH_OUTPUT=$(cd "${JOB_DIR:-.}" && bash -c "$JOB_CMD" 2>&1) || BASH_RC=$?

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -2418,6 +2418,24 @@ JSON
   [ "$output" = "failed" ]
 }
 
+@test "jobs_tick.sh disables bash job when dir is missing" {
+  export JOBS_PATH="${TMP_DIR}/jobs.yml"
+  source "${REPO_DIR}/scripts/lib.sh"
+  init_jobs_file
+
+  MISSING_DIR="${TMP_DIR}/does-not-exist"
+  PROJECT_DIR="$MISSING_DIR" "${REPO_DIR}/scripts/jobs_add.sh" --type bash --command "echo test-output" "* * * * *" "Bad Dir Job" >/dev/null
+
+  run "${REPO_DIR}/scripts/jobs_tick.sh"
+  [ "$status" -eq 0 ]
+
+  run yq -r '.jobs[0].enabled' "$JOBS_PATH"
+  [ "$output" = "false" ]
+
+  run yq -r '.jobs[0].last_task_status' "$JOBS_PATH"
+  [ "$output" = "failed" ]
+}
+
 # --- status.sh ---
 
 @test "status.sh shows counts table" {


### PR DESCRIPTION
## Summary
- detect bash jobs whose configured `dir` does not exist
- auto-disable those jobs and mark last status as failed instead of re-failing every schedule tick
- add a regression test for missing-dir bash jobs

## Changed Files
- scripts/jobs_tick.sh
- tests/orchestrator.bats

## Testing
- LOCK_PATH="/Users/gb/.worktrees/task-20-daily-evening-retrospective-optimize-age/gh-task-41-fix-or-disable-test-bash-job-dir-points-/.orchestrator/test.tasks.lock" bats tests/orchestrator.bats -f "jobs_tick.sh runs bash job"
- LOCK_PATH="/Users/gb/.worktrees/task-20-daily-evening-retrospective-optimize-age/gh-task-41-fix-or-disable-test-bash-job-dir-points-/.orchestrator/test.tasks.lock" bats tests/orchestrator.bats -f "jobs_tick.sh records bash job failure"
- LOCK_PATH="/Users/gb/.worktrees/task-20-daily-evening-retrospective-optimize-age/gh-task-41-fix-or-disable-test-bash-job-dir-points-/.orchestrator/test.tasks.lock" bats tests/orchestrator.bats -f "jobs_tick.sh disables bash job when dir is missing"

Closes #41