### PR TITLE
docs: clarify review decision side effects in review prompt

### DIFF
--- a/prompts/review.md
+++ b/prompts/review.md
@@ -21,3 +21,9 @@ Decision criteria:
 - **approve**: Changes correctly implement the task, no obvious bugs or security issues, tests pass
 - **request_changes**: Changes are on the right track but have issues that should be fixed (missing edge cases, style problems, minor bugs). The author can fix and re-submit.
 - **reject**: Changes are fundamentally wrong — hallucinated APIs/modules, empty or unrelated diff, would obviously break CI (syntax errors, missing imports), or the work makes no sense relative to the task
+
+Important review constraints and side effects:
+- `approve`: posts an approving PR review.
+- `request_changes`: posts a changes-requested review and keeps the PR open for updates. Prefer this when unsure.
+- `reject`: posts a changes-requested review, closes the PR, and marks the task as `needs_review`. Use only for clear hard-fail cases.
+- The PR diff above is truncated to the first 500 lines. If the shown context is insufficient, call that out in `notes` instead of overreaching.


### PR DESCRIPTION
## Summary
- Add explicit decision side-effect notes to `prompts/review.md`
- Document that `reject` closes the PR and marks the task `needs_review`
- Clarify that `request_changes` should be preferred when uncertain
- Disclose that the review diff is truncated to the first 500 lines

## Related
Closes #40
