### PR TITLE
fix: suppress empty retry sections in prompts/agent.md

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -11,21 +11,33 @@ Body:
 Agent profile (JSON):
 {{AGENT_PROFILE_JSON}}
 
+{{#if TASK_HISTORY}}
 Previous attempts on this task:
 {{TASK_HISTORY}}
+{{/if}}
 
+{{#if TASK_LAST_ERROR}}
 Last error: {{TASK_LAST_ERROR}}
+{{/if}}
 
+{{#if TASK_HISTORY}}
 IMPORTANT: If you see repeated failures above, try a DIFFERENT approach. Do not repeat what already failed.
+{{/if}}
 
+{{#if ISSUE_COMMENTS}}
 GitHub issue comments (most recent):
 {{ISSUE_COMMENTS}}
+{{/if}}
 
+{{#if TASK_CONTEXT}}
 Context from prior runs:
 {{TASK_CONTEXT}}
+{{/if}}
 
+{{#if PARENT_CONTEXT}}
 Parent context:
 {{PARENT_CONTEXT}}
+{{/if}}
 
 Project instructions:
 {{PROJECT_INSTRUCTIONS}}
@@ -35,5 +47,7 @@ Project instructions:
 Repository structure:
 {{REPO_TREE}}
 
+{{#if GIT_DIFF}}
 Git diff (current changes):
 {{GIT_DIFF}}
+{{/if}}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -196,6 +196,19 @@ import os, sys, re
 path = sys.argv[1]
 with open(path, "r", encoding="utf-8") as fh:
     data = fh.read()
+# Support simple conditional blocks:
+# {{#if VAR}} ... {{/if}}
+# A block renders only when VAR exists and is not whitespace-only.
+pattern = re.compile(r"\{\{#if\s+(\w+)\}\}(.*?)\{\{/if\}\}", re.DOTALL)
+while True:
+    changed = [False]
+    def repl_if(m):
+        changed[0] = True
+        value = os.environ.get(m.group(1), "")
+        return m.group(2) if value.strip() else ""
+    data = pattern.sub(repl_if, data)
+    if not changed[0]:
+        break
 data = re.sub(r'\{\{(\w+)\}\}', lambda m: os.environ.get(m.group(1), ''), data)
 sys.stdout.write(data)
 PY

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -951,6 +951,39 @@ YAML
   [[ "$output" == *"template not found"* ]]
 }
 
+@test "render_template omits if block when value is empty or whitespace" {
+  TEMPLATE_PATH="${TMP_DIR}/tmpl-if-empty.md"
+  cat > "$TEMPLATE_PATH" <<'EOF'
+start
+{{#if OPTIONAL}}
+optional section
+{{OPTIONAL}}
+{{/if}}
+end
+EOF
+
+  run bash -c "source '${REPO_DIR}/scripts/lib.sh'; OPTIONAL='   ' render_template '$TEMPLATE_PATH'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"start"* ]]
+  [[ "$output" == *"end"* ]]
+  [[ "$output" != *"optional section"* ]]
+}
+
+@test "render_template keeps if block when value is non-empty" {
+  TEMPLATE_PATH="${TMP_DIR}/tmpl-if-filled.md"
+  cat > "$TEMPLATE_PATH" <<'EOF'
+{{#if OPTIONAL}}
+optional section
+{{OPTIONAL}}
+{{/if}}
+EOF
+
+  run bash -c "source '${REPO_DIR}/scripts/lib.sh'; OPTIONAL='value present' render_template '$TEMPLATE_PATH'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"optional section"* ]]
+  [[ "$output" == *"value present"* ]]
+}
+
 @test "create_task_entry creates task via shared helper" {
   NOW="2026-01-01T00:00:00Z"
   export NOW PROJECT_DIR="$TMP_DIR"


### PR DESCRIPTION
## Summary

Suppresses empty retry-context sections in the agent prompt on first attempt by adding conditional template rendering.

## Changes

- Added `{{#if VAR}}...{{/if}}` support in `render_template` with whitespace-aware checks
- Wrapped retry-only sections in `prompts/agent.md` so empty values do not render headings
- Added tests covering conditional block omission and inclusion behavior

## Validation

- Render check: empty/whitespace values no longer output optional section headings
- Render check: populated values still render all optional sections
- `env -u LOCK_PATH -u TASKS_PATH -u ORCH_HOME bats tests/orchestrator.bats --filter 'render_template|agent prompt includes error history and issue comments sections'`
- `env -u LOCK_PATH -u TASKS_PATH -u ORCH_HOME bats tests/orchestrator.bats` (fails in pre-existing unrelated tests)

## Related

Closes #38
