### PR TITLE
feat: enhance build_git_diff() for retries with diff content and commit log

### DIFF
--- a/prompts/agent.md
+++ b/prompts/agent.md
@@ -48,6 +48,6 @@ Repository structure:
 {{REPO_TREE}}
 
 {{#if GIT_DIFF}}
-Git diff (current changes):
+Git diff (prior progress from previous attempts):
 {{GIT_DIFF}}
 {{/if}}

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -661,8 +661,33 @@ build_parent_context() {
 
 build_git_diff() {
   local dir="${1:-$PROJECT_DIR}"
+  local base="${2:-main}"
   if [ -z "$dir" ] || [ ! -d "$dir" ]; then return; fi
-  (cd "$dir" && git diff --stat HEAD 2>/dev/null | head -50) || true
+
+  local stat diff_content log_content
+
+  # Always show stat of uncommitted changes
+  stat=$(cd "$dir" && git diff --stat HEAD 2>/dev/null | head -50) || true
+  if [ -n "$stat" ]; then
+    printf '%s\n' "Uncommitted changes:"
+    printf '%s\n' "$stat"
+    printf '%s\n' ""
+  fi
+
+  # Show diff against base branch (truncated to 200 lines)
+  diff_content=$(cd "$dir" && git diff "$base"...HEAD 2>/dev/null | head -200) || true
+  if [ -n "$diff_content" ]; then
+    printf '%s\n' "Diff against $base:"
+    printf '%s\n' "$diff_content"
+    printf '%s\n' ""
+  fi
+
+  # Show commit log since base branch
+  log_content=$(cd "$dir" && git log "$base"..HEAD --oneline 2>/dev/null | head -20) || true
+  if [ -n "$log_content" ]; then
+    printf '%s\n' "Commits since $base:"
+    printf '%s\n' "$log_content"
+  fi
 }
 
 load_task() {

--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -275,7 +275,7 @@ export REPO_TREE
 REPO_TREE=$(build_repo_tree "$PROJECT_DIR")
 export GIT_DIFF
 if [ "$ATTEMPTS" -gt 0 ]; then
-  GIT_DIFF=$(build_git_diff "$PROJECT_DIR")
+  GIT_DIFF=$(build_git_diff "$PROJECT_DIR" "$DEFAULT_BRANCH")
 else
   GIT_DIFF=""
 fi


### PR DESCRIPTION
## Summary

- Enhanced `build_git_diff()` in `scripts/lib.sh` to include actual diff content (truncated to 200 lines) and commit log (truncated to 20 entries) on retries, so agents understand prior progress
- Added base branch parameterization (second arg, defaults to `main`)
- Used `printf '%s\n'` instead of `printf '%b'` to prevent backslash escape corruption in diff content
- Updated `prompts/agent.md` template header to clarify "prior progress from previous attempts"
- Updated `run_task.sh` to pass `$DEFAULT_BRANCH` to `build_git_diff()`
- Added 6 bats tests: stat output, diff against base, commit log, empty case, 200-line truncation, and custom base branch

## Test plan

- [x] All 6 new `build_git_diff` tests pass
- [x] Full test suite (234 tests) — no new regressions (15 pre-existing failures unchanged)
- [ ] Manual verification: retry a task and confirm the enhanced diff appears in the agent prompt

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)