### PR TITLE
feat: label validation, model visibility, remove worktree skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Agents execute inside `$PROJECT_DIR` (the directory you ran `orchestrator` from)
 Agents are constrained by rules in the system prompt:
 - **No `rm`**: `--disallowedTools` blocks `rm` — agents must use `trash` (macOS) or `trash-put` (Linux)
 - **No commits to main**: Agents must always work in feature branches
-- **Required skills**: Skills listed in `workflow.required_skills` are marked `[REQUIRED]` in the agent prompt and must be followed exactly (e.g. `gh-issue-worktree` for branch/PR workflow)
+- **Required skills**: Skills listed in `workflow.required_skills` are marked `[REQUIRED]` in the agent prompt and must be followed exactly
 - **GitHub issue linking**: If a task has a linked issue, the agent receives the issue reference for branch naming and PR linking
 - **Cost-conscious sub-agents**: Agents are instructed to use cheap models for routine sub-agent work
 
@@ -353,7 +353,6 @@ Skills listed in `workflow.required_skills` are always injected into agent promp
 ```yaml
 workflow:
   required_skills:
-    - gh-issue-worktree   # branch/PR workflow
     - github              # GitHub CLI operations
     - gh-pr-polish        # PR titles and bodies
 ```

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -50,8 +50,7 @@ gh:
   project_id: "PVT_..."
 workflow:
   enable_review_agent: true
-  required_skills:
-    - gh-issue-worktree
+  required_skills: []
 router:
   fallback_executor: "claude"
 ```

--- a/scripts/route_task.sh
+++ b/scripts/route_task.sh
@@ -134,10 +134,7 @@ if [ "${CMD_STATUS:-0}" -ne 0 ]; then
       "status=routed" \
       "route_reason=$REASON" \
       "agent_profile=$PROFILE_JSON"
-    # Add labels
     db_add_label "$TASK_ID" "agent:${ROUTED_AGENT}"
-    db_add_label "$TASK_ID" "role:general"
-    db_add_label "$TASK_ID" "complexity:${COMPLEXITY}"
 
     append_history "$TASK_ID" "routed" "$REASON"
     log_err "[route] task=$TASK_ID fallback to ${ROUTED_AGENT}"
@@ -239,8 +236,6 @@ fi
 
 # Add routing labels
 db_add_label "$TASK_ID" "agent:${ROUTED_AGENT}"
-db_add_label "$TASK_ID" "role:${ROLE}"
-db_add_label "$TASK_ID" "complexity:${COMPLEXITY}"
 if [ -n "$DECOMPOSE_LABEL" ]; then
   db_add_label "$TASK_ID" "$DECOMPOSE_LABEL"
 fi

--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -417,6 +417,11 @@ if [ -z "$AGENT_MODEL" ] || [ "$AGENT_MODEL" = "null" ]; then
   AGENT_MODEL=$(model_for_complexity "$TASK_AGENT" "${TASK_COMPLEXITY:-medium}")
 fi
 
+# Set model: label on the issue for visibility (diagnostic, not blocking)
+if [ -n "$AGENT_MODEL" ] && [ "$AGENT_MODEL" != "null" ]; then
+  _gh_set_prefixed_label "$TASK_ID" "$_GH_MODEL_PREFIX" "$AGENT_MODEL" 2>/dev/null || true
+fi
+
 CMD_STATUS=0
 TMUX_RESPONSE_FILE="${STATE_DIR}/${FILE_PREFIX}-tmux-response-${ATTEMPTS}.txt"
 TMUX_STATUS_FILE="${STATE_DIR}/${FILE_PREFIX}-tmux-status-${ATTEMPTS}.txt"


### PR DESCRIPTION
## Summary

- **Label validation**: reserved prefixes (`status:`, `agent:`, `model:`, `skill:`, `job:`) are validated before creation — invalid values rejected with log message, user labels pass through freely
- **Model visibility**: `model:` label set on issues after model resolution (diagnostic, not blocking)
- **Sidecar-only fields**: `complexity:` and `role:` moved out of labels into sidecar + agent comments (saves 2 API calls per route)
- **Worktree skills removed**: `gh-issue-worktree` and `git-worktree` removed from required/default skills — orchestrator owns worktree lifecycle

## Test plan

- [x] 15 new label validation tests added
- [x] Full suite: 221 tests, 0 failures
- [x] Existing route_task tests updated for sidecar-only complexity
- [x] Config cleanup verified (`~/.orchestrator/config.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)