### PR TITLE
chore: Close duplicate improvement issues from repeated retrospectives (#167)

### DIFF
--- a/docs/plan-github-native.md
+++ b/docs/plan-github-native.md
@@ -187,7 +187,12 @@ evening-retrospective:
   schedule: "0 18 * * *"
   type: task
   labels: "scheduled,agent:claude"
-  body: "Review completed and failed tasks, suggest improvements."
+  body: |
+    Review completed and failed tasks, and suggest improvements.
+
+    Before creating improvement tasks, search existing open issues for similar titles.
+    Use: gh issue list --repo owner/repo --state open --search "<topic>"
+    Only create a new issue if no similar open issue exists.
   last_run: "2026-02-20T18:00:00Z"
 ```
 


### PR DESCRIPTION
## Summary

- 1d2204e fix(prompts): dedupe system prompt rules
- 9d6cea3 docs(jobs): add retrospective issue dedupe step
- 25ea6ff chore(pr): add gh PR helper scripts
- 9a7c168 fix(pr): make PR helper scripts generic

## Changes

-  docs/plan-github-native.md |  7 ++++-
-  prompts/system.md          |  2 --
-  scripts/create-pr.sh       | 42 ++++++++++++++++++++++++++
-  scripts/make-pr-body.sh    | 74 ++++++++++++++++++++++++++++++++++++++++++++++

 4 files changed, 122 insertions(+), 3 deletions(-)

Closes #167
