### PR TITLE
feat: auto-reroute tasks to fallback agent on usage limit errors

### DIFF
--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -789,7 +789,7 @@ reroute_on_usage_limit() {
   if [ -n "$TASK_AGENT" ]; then
     if [ -z "$chain" ]; then
       chain="$TASK_AGENT"
-    elif ! printf ',%s,' "$chain" | grep -q ",${TASK_AGENT},"; then
+    elif ! printf ',%s,' "$chain" | grep -qF ",${TASK_AGENT},"; then
       chain="${chain},${TASK_AGENT}"
     fi
   fi
@@ -816,6 +816,9 @@ ${snippet}
   fi
 
   local next_model=""
+  local FREE_MODELS=""
+  local -a _fm=()
+  local -a _chain=()
   if [ "$next_agent" = "opencode" ]; then
     FREE_MODELS=$(config_get '.model_map.free // [] | join(",")' 2>/dev/null || true)
     if [ -n "${FREE_MODELS:-}" ]; then
@@ -1026,8 +1029,12 @@ db_store_agent_response "$TASK_ID" "$AGENT_STATUS" "$SUMMARY" "$REASON" \
 
 db_store_agent_arrays "$TASK_ID" "$ACCOMPLISHED_STR" "$REMAINING_STR" "$BLOCKERS_STR" "$FILES_CHANGED_STR"
 
-# Clear usage-limit reroute chain on any non-rerouted completion path.
-db_task_update "$TASK_ID" "limit_reroute_chain=NULL" 2>/dev/null || true
+# Clear usage-limit reroute chain only when task reaches a terminal success state.
+# Do NOT clear on in_progress — the next iteration could still hit a limit and we
+# need the chain intact to prevent ping-pong back to an already-exhausted agent.
+if [ "$AGENT_STATUS" = "done" ]; then
+  db_task_update "$TASK_ID" "limit_reroute_chain=NULL" 2>/dev/null || true
+fi
 
 # Fallback: auto-commit any uncommitted changes the agent left behind
 if [ "$AGENT_STATUS" = "done" ] || [ "$AGENT_STATUS" = "in_progress" ]; then


### PR DESCRIPTION
## Summary

- Adds `is_usage_limit_error()` helper in `scripts/lib.sh` to detect rate/usage limit errors via regex (429, too many requests, rate-limit, quota exceeded, overloaded, etc.)
- Adds `pick_fallback_agent()` helper that rotates to the next available agent, skipping a configurable exclude list to prevent ping-pong
- Adds `reroute_on_usage_limit()` in `scripts/run_task.sh` that auto-reroutes tasks when usage/rate limits are detected:
  - On non-zero exit code with usage-limit output
  - On invalid/empty JSON response (likely agent crash due to limit)
  - On agent response with missing status field
- Tracks `limit_reroute_chain` per-task to avoid bouncing between agents; chain only clears on `done`
- Posts GitHub issue comment with snippet when rerouting or when no fallback is available
- Extracts auth/billing error path to use `pick_fallback_agent()` for consistency

## Test plan
- [x] 237 bats tests passing including 3 reroute-specific tests
- [x] Auto-reroutes on usage limit (agent-reported needs_review)
- [x] Auto-reroutes on non-JSON response (crash/limit)
- [x] Preserves limit_reroute_chain on in_progress completions (ping-pong prevention)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)