### PR TITLE
fix: jobs_tick null last_run catch-up, needs_review guard, 1800s timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,7 @@ All runtime configuration lives in `config.yml`.
 | `workflow` | `enable_review_agent` | Run a review agent after completion. | `false` |
 | `workflow` | `review_agent` | Fallback reviewer when opposite agent unavailable. | `claude` |
 | `workflow` | `max_attempts` | Max attempts before marking task as blocked. | `10` |
+| `workflow` | `agent_timeout_seconds` | Max time (seconds) per agent run. Increase for complex tasks. | `1800` |
 | `workflow` | `required_skills` | Skills always injected into agent prompts (marked `[REQUIRED]`). | `[]` |
 | `workflow` | `disallowed_tools` | Tool patterns blocked via `--disallowedTools`. | `["Bash(rm *)","Bash(rm -*)"]` |
 | `router` | `agent` | Default router executor. | `claude` |

--- a/config.example.yml
+++ b/config.example.yml
@@ -5,6 +5,7 @@ workflow:
   enable_review_agent: false
   review_agent: "claude"
   max_attempts: 10
+  agent_timeout_seconds: 1800  # Max time per agent run. Increase for complex tasks (default: 1800s).
 router:
   agent: "claude"
   model: "haiku"

--- a/docs/content/configuration.md
+++ b/docs/content/configuration.md
@@ -16,6 +16,7 @@ All runtime configuration lives in `~/.orchestrator/config.yml`.
 | `workflow` | `enable_review_agent` | Run a [review agent](@/review-agent.md) after task completion | `false` |
 | `workflow` | `review_agent` | Fallback reviewer when opposite agent unavailable | `claude` |
 | `workflow` | `max_attempts` | Max attempts before marking task as blocked | `10` |
+| `workflow` | `agent_timeout_seconds` | Max time (seconds) per agent run. Increase for complex tasks. | `1800` |
 | `workflow` | `stuck_timeout` | Timeout (seconds) for detecting stuck in_progress tasks | `1800` |
 | `workflow` | `required_skills` | Skills always injected into agent prompts (marked `[REQUIRED]`) | `[]` |
 | `workflow` | `disallowed_tools` | Tool patterns blocked via `--disallowedTools` | `["Bash(rm *)","Bash(rm -*)"]` |

--- a/scripts/backend_github.sh
+++ b/scripts/backend_github.sh
@@ -561,12 +561,12 @@ db_normalize_new_issues() {
   json=$(gh_api -X GET "repos/$_GH_REPO/issues" \
     -f state=open -f per_page=50 -f sort=created -f direction=desc 2>/dev/null) || return 0
 
-  # Find issues (not PRs) without any status: label, excluding no-agent and blocked
+  # Find issues (not PRs) without any status: label, excluding no-agent, blocked, and needs_review
   local unlabeled_ids
   unlabeled_ids=$(printf '%s' "$json" | jq -r --arg p "$_GH_STATUS_PREFIX" '
     [.[] | select(.pull_request == null)
          | select((.labels // []) | map(.name) | all(startswith($p) | not))
-         | select((.labels // []) | map(.name) | all(. != "no-agent" and . != "blocked"))]
+         | select((.labels // []) | map(.name) | all(. != "no-agent" and . != "blocked" and . != "needs_review"))]
     | .[].number' 2>/dev/null || true)
 
   [ -n "$unlabeled_ids" ] || return 0

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -947,7 +947,7 @@ process_owner_feedback() {
 }
 
 run_with_timeout() {
-  local timeout_seconds=${AGENT_TIMEOUT_SECONDS:-900}
+  local timeout_seconds=${AGENT_TIMEOUT_SECONDS:-1800}
   if command -v timeout >/dev/null 2>&1; then
     timeout "$timeout_seconds" "$@"
     return $?


### PR DESCRIPTION
## Summary

Morning review fixes for reliability and agent success rate:

- **fix(jobs_tick)**: synthesize 24h lookback when `last_run` is null so catch-up fires correctly on the first scheduler run (fixes #163)
- **fix(run_task)**: guard against re-running `needs_review` tasks at startup — exit 0 immediately without touching the agent (fixes #164)
- **fix(lib,run_task)**: increase default agent timeout from 900s → 1800s in `run_with_timeout` and all `tmux_wait` calls; reads from `config.yml` `workflow.agent_timeout_seconds` (fixes #166)
- **fix(backend_github)**: exclude `needs_review` issues from unlabeled normalization to prevent unwanted status resets
- **docs**: document `agent_timeout_seconds` in README, `config.example.yml`, and `docs/content/configuration.md`

## Test plan

- [x] `bats tests/orchestrator.bats --filter "needs_review"` → new test passes
- [x] `bats tests/orchestrator.bats --filter "jobs_tick"` → all 11 jobs_tick tests pass
- [x] Full test suite clean (no regressions)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)