### PR TITLE
feat: auto-reroute tasks to fallback agent on usage limit errors

### DIFF
--- a/scripts/retry_task.sh
+++ b/scripts/retry_task.sh
@@ -19,6 +19,6 @@ if [ "$STATUS" = "new" ] || [ "$STATUS" = "routed" ] || [ "$STATUS" = "in_progre
   exit 0
 fi
 
-db_task_update "$TASK_ID" "status=new" "agent=NULL"
+db_task_update "$TASK_ID" "status=new" "agent=NULL" "limit_reroute_chain=NULL"
 append_history "$TASK_ID" "new" "retried from $STATUS"
 log "[retry] task=$TASK_ID reset from $STATUS to new"


### PR DESCRIPTION
## Summary

- Adds `is_usage_limit_error()` helper in `scripts/lib.sh` to detect rate/usage limit errors via regex (429, too many requests, rate-limit, quota exceeded, overloaded, etc.)
- Adds `pick_fallback_agent()` helper that rotates to the next available agent, skipping a configurable exclude list to prevent ping-pong
- Adds `reroute_on_usage_limit()` in `scripts/run_task.sh` that auto-reroutes tasks when usage/rate limits are detected:
  - On non-zero exit code with usage-limit output
  - On invalid/empty JSON response (likely agent crash due to limit)
  - On agent response with missing status field
  - On agent-reported needs_review/blocked with rate-limit reason
- Tracks `limit_reroute_chain` per-task to avoid bouncing between agents; chain clears on `done` or manual retry
- Posts GitHub issue comment with redacted snippet when rerouting or when no fallback is available
- Extracts auth/billing error path to use `pick_fallback_agent()` for consistency
- Adds `redact_snippet()` helper to strip API keys/tokens before posting to GitHub
- Clears `limit_reroute_chain` in `retry_task.sh` when task is manually reset to new

## Changes from PR review feedback (PR #188)
- Tightened `is_usage_limit_error` regex: removed overly broad `service unavailable` and `temporarily unavailable` patterns; kept only Anthropic-specific `service overloaded`
- Restored bare `\bquota\b` match that was accidentally dropped
- Added `redact_snippet()` to prevent accidental credential leaks in GitHub comments
- Fixed opencode free-model index in `reroute_on_usage_limit`: count opencode occurrences in chain instead of total chain length
- Restored history-based `FREE_IDX` in auth/billing path
- Clear `limit_reroute_chain` in `retry_task.sh` on manual requeue
- Added positive and negative BATS tests for `is_usage_limit_error`

## Test plan
- [x] 239 bats tests passing including 4 reroute-specific tests + 7 is_usage_limit_error unit tests
- [x] Auto-reroutes on usage limit (agent-reported needs_review)
- [x] Auto-reroutes on non-JSON response (crash/limit)
- [x] Preserves limit_reroute_chain on in_progress completions (ping-pong prevention)
- [x] 503 Service Unavailable does NOT trigger reroute (negative test)
- [x] Bare 'temporarily unavailable' does NOT trigger reroute (negative test)
- [x] Generic auth errors do NOT trigger reroute (negative test)

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)