### PR TITLE
fix(mentions): ignore quoted @orchestrator references

### DIFF
--- a/scripts/gh_mentions.sh
+++ b/scripts/gh_mentions.sh
@@ -90,6 +90,21 @@ mention_actionable() {
     /^[[:space:]]*>/ { next; }
     {
       line = $0
+
+      # Remove inline code and quoted substrings to reduce false positives from
+      # status updates that merely reference an @orchestrator mention.
+      # - Inline code: `...`
+      # - Double quotes: "..."
+      # - Single quotes: '...'
+      while (match(line, /`[^`]*`/)) {
+        line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
+      }
+      while (match(line, /"[^"]*"/)) {
+        line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
+      }
+      while (match(line, /\047[^\047]*\047/)) {
+        line = substr(line, 1, RSTART - 1) substr(line, RSTART + RLENGTH)
+      }
       if (tolower(line) ~ /(^|[^a-z0-9_])@orchestrator([^a-z0-9_-]|$)/) { hit = 1; exit; }
     }
     END { exit(hit ? 0 : 1); }

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -2054,6 +2054,30 @@ SH
   [ "$output" -eq 1 ]
 }
 
+@test "@orchestrator mention inside double quotes is ignored" {
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body=$'FYI I saw ("@orchestrator fix.") in another thread.'
+  [ "$status" -eq 0 ]
+
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "@orchestrator mention inside inline code is ignored" {
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body=$'Example: `@orchestrator fix`'
+  [ "$status" -eq 0 ]
+
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
 @test "create_task_entry includes last_comment_hash field" {
   NOW="2026-01-01T00:00:00Z"
   export NOW PROJECT_DIR="$TMP_DIR"


### PR DESCRIPTION
## Summary

- fix(mentions): ignore quoted @orchestrator references

## Testing

`HOME=/tmp/orch-test-home bats tests/orchestrator.bats`

Closes #211
