### PR TITLE
docs: add 2026-02-22 retrospective

### DIFF
--- a/docs/content/posts/retrospective-2026-02-22.md
+++ b/docs/content/posts/retrospective-2026-02-22.md
@@ -1,0 +1,12 @@
++++
+title = "Retrospective — 2026-02-22"
+date = "2026-02-22"
++++
+
+## Summary
+
+Triaged an `@orchestrator` mention on #192 that referenced prior work on #158.
+
+**Finding:** #158 was already fully implemented and merged via PR #162 (`feat(status): show open task count`), despite the original codex run timing out mid-run.
+
+**Action taken:** Posted a clarification comment on #192 and linked back to the results summary on #158 for future readers.


### PR DESCRIPTION
## Summary

- docs: add 2026-02-22 retrospective

## Testing

`HOME=/tmp/orch-test-home bats tests/orchestrator.bats`

Closes #208
