### PR TITLE
docs(github): document mentions listener

### DIFF
--- a/docs/content/github-sync.md
+++ b/docs/content/github-sync.md
@@ -53,6 +53,17 @@ When an agent completes a task, the orchestrator posts a structured comment:
 - **Collapsed sections**: stderr output and full prompt (with hash)
 - **Content-hash dedup**: identical comments not re-posted
 
+### GitHub Mentions Listener
+
+If enabled (via `gh.enabled: true`), the orchestrator can also watch for `@orchestrator` mentions in issue/PR comments and automatically create a task to respond.
+
+- The listener lives in `scripts/gh_mentions.sh`.
+- It posts an acknowledgement comment with the `<!-- orch:mention -->` marker so the listener won’t re-trigger on orchestrator-generated comments.
+- Mentions are ignored when they only appear in:
+  - fenced code blocks (``` / ~~~)
+  - Markdown blockquotes (`>` lines)
+  - orchestrator-generated comments (`<!-- orch:* -->` or `via [Orchestrator]`)
+
 ### Labels
 
 - `status:<status>` — task status (`new`, `routed`, `in_progress`, `done`, `needs_review`, `blocked`)


### PR DESCRIPTION
## Summary

- docs(github): document mentions listener
- fix(mentions): ignore quoted @orchestrator references (#227)
- docs(development): note ShellCheck backtick gotcha (#226)
- docs: add 2026-02-22 retrospective (#228)
- fix(status): align totals with status counts (#199)
- fix(status): align totals with status counts (#194)

## Testing

`HOME=/tmp/orch-test-home bats tests/orchestrator.bats`

Closes #244
