### PR TITLE
fix(mentions): ignore multi-backtick inline code

### DIFF
--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -2123,6 +2123,18 @@ YAML
   [ "$output" -eq 1 ]
 }
 
+@test "@orchestrator mention inside double-backtick inline code is ignored" {
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body=$'Example: ``@orchestrator fix``'
+  [ "$status" -eq 0 ]
+
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
 @test "create_task_entry includes last_comment_hash field" {
   NOW="2026-01-01T00:00:00Z"
   export NOW PROJECT_DIR="$TMP_DIR"


### PR DESCRIPTION
## Summary

- fix(mentions): ignore multi-backtick inline code

## Testing

`HOME=/tmp/orch-test-home bats tests/orchestrator.bats`

Closes #274
