### PR TITLE
fix(mentions): dedup skips re-trigger on closed issues even when prior tasks are done

### DIFF
--- a/scripts/gh_mentions.sh
+++ b/scripts/gh_mentions.sh
@@ -196,17 +196,17 @@ main() {
     issue_number=$(printf '%s' "$issue_url" | sed -E 's#.*/issues/([0-9]+).*#\1#')
     [ -n "$issue_number" ] || continue
 
+    local seen_at
+    seen_at="${updated_at:-$created_at}"
+    if [ -n "$seen_at" ] && [ "$seen_at" \> "$max_seen" ]; then
+      max_seen="$seen_at"
+    fi
+
     # Skip comments on closed issues — no point creating tasks for them
     local _issue_state
     _issue_state=$(gh_api "repos/${repo}/issues/${issue_number}" --cache 120s -q '.state' 2>/dev/null || true)
     if [ "$_issue_state" = "closed" ]; then
       continue
-    fi
-
-    local seen_at
-    seen_at="${updated_at:-$created_at}"
-    if [ -n "$seen_at" ] && [ "$seen_at" \> "$max_seen" ]; then
-      max_seen="$seen_at"
     fi
 
     if ! printf '%s' "$comment_body" | rg -qi "@orchestrator"; then
@@ -230,6 +230,20 @@ main() {
     _active_tasks=$(jq -r --argjson inum "$issue_number" \
       '[.processed | to_entries[] | select(.value.issue_number == $inum) | .value.task_id] | .[]' \
       "$MENTIONS_DB_PATH" 2>/dev/null || true)
+
+    # If prior tasks exist for this issue, re-verify issue state without cache.
+    # The initial check uses --cache 120s; a stale "open" response could let a
+    # comment through on an already-closed issue. Rechecking here ensures that
+    # done tasks on closed issues don't re-trigger new task creation.
+    if [ -n "$_active_tasks" ]; then
+      local _fresh_state
+      _fresh_state=$(gh_api "repos/${repo}/issues/${issue_number}" -q '.state' 2>/dev/null || true)
+      if [ "$_fresh_state" = "closed" ]; then
+        log_err "[mentions] skipping issue #$issue_number — issue is closed, prior mention tasks exist"
+        continue
+      fi
+    fi
+
     for _tid in $_active_tasks; do
       local _st
       _st=$(db_task_field "$_tid" "status" 2>/dev/null || true)

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -2327,6 +2327,92 @@ YAML
   [ "$output" -eq 1 ]
 }
 
+@test "@orchestrator mention on closed issue is skipped" {
+  # Create a comment on the init issue, then close it
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body="@orchestrator please help"
+  [ "$status" -eq 0 ]
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}" -X PATCH -f state=closed
+  [ "$status" -eq 0 ]
+
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  # No new task should be created since the issue is closed
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
+@test "@orchestrator mention on closed issue with done task does not re-trigger" {
+  # Comment on open issue — creates a task
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body="@orchestrator do something"
+  [ "$status" -eq 0 ]
+
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 2 ]
+
+  MENTION_TASK_ID=$(_task_id_by_title "Respond to @orchestrator mention in #${INIT_TASK_ID}")
+  [ -n "$MENTION_TASK_ID" ]
+
+  # Simulate the mention task completing
+  run bash -c "
+    source '${REPO_DIR}/scripts/lib.sh'
+    db_store_agent_response '$MENTION_TASK_ID' done 'handled' '' false '' 1 0 0 '' ''
+  "
+  [ "$status" -eq 0 ]
+
+  # Close the issue
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}" -X PATCH -f state=closed
+  [ "$status" -eq 0 ]
+
+  # Second comment on the now-closed issue
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body="@orchestrator actually do more"
+  [ "$status" -eq 0 ]
+
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  # No new task should be created — prior task is done but issue is closed
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 2 ]
+}
+
+@test "@orchestrator mention on closed issue advances since so comments are not re-fetched" {
+  # Create a comment and close the issue
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}/comments" -f body="@orchestrator help"
+  [ "$status" -eq 0 ]
+  run gh api "repos/mock/repo/issues/${INIT_TASK_ID}" -X PATCH -f state=closed
+  [ "$status" -eq 0 ]
+
+  # First poll — no task created, but since should advance past this comment
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  repo_key=$(printf 'mock/repo' | tr '/:' '__')
+  mentions_db="${ORCH_HOME}/.orchestrator/mentions/${repo_key}.json"
+  since_before=$(jq -r '.since' "$mentions_db")
+
+  # Second poll — should not re-fetch or re-process the same comment
+  run gh_mentions.sh
+  [ "$status" -eq 0 ]
+
+  since_after=$(jq -r '.since' "$mentions_db")
+
+  # since should have advanced (not stuck at the initial value)
+  [ "$since_after" != "1970-01-01T00:00:00Z" ]
+  [ "$since_before" = "$since_after" ]
+
+  # Still no new task
+  run tdb_count
+  [ "$status" -eq 0 ]
+  [ "$output" -eq 1 ]
+}
+
 @test "create_task_entry includes last_comment_hash field" {
   NOW="2026-01-01T00:00:00Z"
   export NOW PROJECT_DIR="$TMP_DIR"


### PR DESCRIPTION
## Summary

- **Gap 1 (max_seen not advancing)**: The `max_seen` timestamp was not updated for closed-issue comments because the `continue` fired before the update. This caused those comments to be re-fetched on every poll cycle without ever creating tasks.
- **Gap 2 (stale cache bypass)**: When all prior mention tasks for an issue were `done`, a new comment on the same (now-closed) issue could create another task — especially if the initial closed-issue check used a stale 120s-cached `open` response.

## Changes

- Moved `max_seen` update before the closed-issue `continue` so closed-issue comments always advance `since`
- In the per-issue dedup block, if any prior tasks exist for an issue, re-check the issue state **without cache**. If the issue is now closed, skip creation regardless of prior task status

## Test plan

- [x] `@orchestrator mention on closed issue is skipped` — no task created for comment on closed issue
- [x] `@orchestrator mention on closed issue with done task does not re-trigger` — after prior task completes and issue is closed, new comment does not create another task
- [x] `@orchestrator mention on closed issue advances since so comments are not re-fetched` — `since` advances past closed-issue comments
- [x] All 268 existing tests still pass

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)