### PR TITLE
Centralize PATH setup; prevent duplicate job runs

### DIFF
--- a/scripts/jobs_tick.sh
+++ b/scripts/jobs_tick.sh
@@ -126,6 +126,10 @@ for JOB_ID in $JOB_IDS; do
   fi
 
   # Task job: create a task for agent processing
+  # Update last_run BEFORE creation to prevent duplicate catch-up runs
+  NOW=$(now_iso)
+  db_job_set "$JOB_ID" "last_run" "$NOW"
+
   # Add job tracking labels
   if [ -n "$JOB_LABELS" ] && [ "$JOB_LABELS" != "null" ]; then
     JOB_LABELS="${JOB_LABELS},scheduled,job:${JOB_ID}"
@@ -142,8 +146,6 @@ for JOB_ID in $JOB_IDS; do
   fi
 
   # Update job state
-  NOW=$(now_iso)
-  db_job_set "$JOB_ID" "last_run" "$NOW"
   db_job_set "$JOB_ID" "active_task_id" "$NEW_TASK_ID"
 
   export TASK_ID="$NEW_TASK_ID"

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -13,6 +13,24 @@ LOCK_PATH=${LOCK_PATH:-"${ORCH_HOME}/.orchestrator/locks"}
 CONTEXTS_DIR=${CONTEXTS_DIR:-"${ORCH_HOME}/contexts"}
 CONFIG_PATH=${CONFIG_PATH:-"${ORCH_HOME}/config.yml"}
 STATE_DIR=${STATE_DIR:-"${ORCH_HOME}/.orchestrator"}
+
+# Augment PATH and load functions (brew services / launchd start with minimal env)
+_path_found=false
+if [[ -f "$HOME/.path" ]]; then
+  _old_path="$PATH"
+  source "$HOME/.path" >/dev/null 2>&1
+  export PATH="${_old_path}:${PATH}"
+  _path_found=true
+fi
+if [[ -f "$HOME/.functions" ]]; then
+  source "$HOME/.functions" >/dev/null 2>&1
+fi
+# Fallback dev tool locations if no .path file found
+if ! $_path_found; then
+  for _p in "$HOME/.bun/bin" "$HOME/.cargo/bin" "$HOME/.local/share/solana/install/active_release/bin" "$HOME/.local/bin" "/opt/homebrew/bin" "/usr/local/bin"; do
+    [[ -d "$_p" ]] && [[ ":$PATH:" != *":$_p:"* ]] && export PATH="$_p:$PATH"
+  done
+fi
 # Source backend layer (GitHub, etc.)
 _LIB_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 if [ -f "${_LIB_DIR}/backend.sh" ]; then

--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -62,20 +62,6 @@ if [ "$PROJECT_DIR" = "/" ] || { [ ! -d "$PROJECT_DIR/.git" ] && ! is_bare_repo 
 fi
 export PROJECT_DIR
 
-# Augment PATH (brew services / launchd start with minimal PATH)
-# If $HOME/.path exists, source it to pick up user-configured paths;
-# otherwise fall back to common dev tool locations.
-if [[ -f "$HOME/.path" ]]; then
-  _OLD_PATH="$PATH"
-  source "$HOME/.path" >/dev/null 2>&1
-  # Preserve any paths that were already at the front (e.g. test mocks)
-  export PATH="${_OLD_PATH}:${PATH}"
-else
-  for _p in "$HOME/.bun/bin" "$HOME/.cargo/bin" "$HOME/.local/share/solana/install/active_release/bin" "$HOME/.local/bin" "/opt/homebrew/bin" "/usr/local/bin"; do
-    [[ -d "$_p" ]] && [[ ":$PATH:" != *":$_p:"* ]] && export PATH="$_p:$PATH"
-  done
-fi
-
 load_project_config
 
 TASK_ID=${1:-}
@@ -882,7 +868,7 @@ RUNNER_EOF
   opencode)
     # If no model set (round_robin), pick random from agents.opencode.models
     if [ -z "$AGENT_MODEL" ] || [ "$AGENT_MODEL" = "null" ]; then
-      OPENCODE_MODELS=$(config_get '.agents.opencode.models // []' 2>/dev/null || true)
+      OPENCODE_MODELS=$(config_get '.agents.opencode.models // []' 2>/dev/null | yq -o=json - 2>/dev/null || echo "[]")
       if [ -n "$OPENCODE_MODELS" ] && [ "$OPENCODE_MODELS" != "[]" ]; then
         AGENT_MODEL=$(printf '%s' "$OPENCODE_MODELS" | jq -r ".[$(($(date +%s) % $(printf '%s' "$OPENCODE_MODELS" | jq 'length')))]")
       fi


### PR DESCRIPTION
Move PATH augmentation into scripts/lib.sh to ensure user tool paths (.path, .functions) and common dev locations are available in minimal environments (e.g. brew services / launchd). Remove the duplicate PATH logic from run_task.sh. In jobs_tick.sh, update job.last_run before creating a task to avoid duplicate catch-up runs and remove the redundant post-creation update. Also adjust opencode model parsing in run_task.sh to normalize config output to JSON (yq fallback) before using jq.