### PR TITLE
fix: include project name in tmux session names to avoid collisions

### DIFF
--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -512,7 +512,7 @@ ASYNC_TMUX=${ASYNC_TMUX:-$(config_get '.workflow.async_tmux // "true"')}
 _USED_TMUX=false
 TMUX_RESPONSE_FILE="${STATE_DIR}/${FILE_PREFIX}-tmux-response-${ATTEMPTS}.txt"
 TMUX_STATUS_FILE="${STATE_DIR}/${FILE_PREFIX}-tmux-status-${ATTEMPTS}.txt"
-TMUX_SESSION="orch-${TASK_ID}"
+TMUX_SESSION="orch-${PROJECT_NAME}-${TASK_ID}"
 USE_TMUX=${USE_TMUX:-$(config_get '.workflow.use_tmux // "true"')}
 
 # Collect agent output and update task. Called after agent finishes (sync or async).

--- a/scripts/task_attach.sh
+++ b/scripts/task_attach.sh
@@ -10,17 +10,25 @@ if [ -z "$TASK_ID" ]; then
   exit 1
 fi
 
-SESSION="orch-${TASK_ID}"
-
 if ! command -v tmux >/dev/null 2>&1; then
   log_err "tmux is not installed"
   exit 1
 fi
 
-if ! tmux has-session -t "$SESSION" 2>/dev/null; then
-  log_err "No active tmux session for task $TASK_ID (session: $SESSION)"
+# Session names include project: orch-{project}-{task_id}. Search by task ID suffix.
+_SESSIONS=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
+  | grep -E "^orch-.*-${TASK_ID}$" || true)
+SESSION=$(printf '%s' "$_SESSIONS" | head -1)
+
+if [ -z "$SESSION" ]; then
+  log_err "No active tmux session for task $TASK_ID"
   log_err "The agent may have already finished. Check: orch task live"
   exit 1
+fi
+
+_SESSION_COUNT=$(printf '%s\n' "$_SESSIONS" | grep -c . || true)
+if [ "$_SESSION_COUNT" -gt 1 ]; then
+  log_err "Warning: multiple sessions found for task $TASK_ID — attaching to first ($SESSION)"
 fi
 
 log_err "Attaching to $SESSION (detach: Ctrl-B D)"

--- a/scripts/task_kill.sh
+++ b/scripts/task_kill.sh
@@ -10,16 +10,24 @@ if [ -z "$TASK_ID" ]; then
   exit 1
 fi
 
-SESSION="orch-${TASK_ID}"
-
 if ! command -v tmux >/dev/null 2>&1; then
   log_err "tmux is not installed"
   exit 1
 fi
 
-if ! tmux has-session -t "$SESSION" 2>/dev/null; then
+# Session names include project: orch-{project}-{task_id}. Search by task ID suffix.
+_SESSIONS=$(tmux list-sessions -F '#{session_name}' 2>/dev/null \
+  | grep -E "^orch-.*-${TASK_ID}$" || true)
+SESSION=$(printf '%s' "$_SESSIONS" | head -1)
+
+if [ -z "$SESSION" ]; then
   log_err "No active tmux session for task $TASK_ID"
   exit 1
+fi
+
+_SESSION_COUNT=$(printf '%s\n' "$_SESSIONS" | grep -c . || true)
+if [ "$_SESSION_COUNT" -gt 1 ]; then
+  log_err "Warning: multiple sessions found for task $TASK_ID — killing first ($SESSION)"
 fi
 
 log "Killing tmux session $SESSION for task $TASK_ID"

--- a/scripts/task_live.sh
+++ b/scripts/task_live.sh
@@ -23,7 +23,7 @@ printf '  %-20s %-8s %-10s %s\n' "SESSION" "TASK" "AGENT" "STARTED"
 printf '  %-20s %-8s %-10s %s\n' "-------" "----" "-----" "-------"
 
 while IFS=' ' read -r name created activity; do
-  TASK_ID="${name#orch-}"
+  TASK_ID="${name##*-}"
   AGENT=$(db_task_field "$TASK_ID" "agent" 2>/dev/null || echo "?")
   TITLE=$(db_task_field "$TASK_ID" "title" 2>/dev/null || echo "")
   TITLE="${TITLE:0:40}"


### PR DESCRIPTION
## Summary

- Include `PROJECT_NAME` in tmux session names: `orch-{project}-{task_id}` instead of `orch-{task_id}`
- Update `task_attach.sh` and `task_kill.sh` to find sessions by suffix pattern matching
- Update `task_live.sh` to correctly extract task ID from the new format

## Problem

With multi-project polling, two projects can have GitHub issues with the same number (e.g., both have issue #5). The old `orch-{task_id}` format caused session name collisions — the second task's `tmux new-session` would kill the first task's session.

## Fix

`PROJECT_NAME` (derived from `basename "$PROJECT_DIR" .git`) is already set when `TMUX_SESSION` is assigned. Changed to `orch-${PROJECT_NAME}-${TASK_ID}` for unique cross-project session names (e.g. `orch-my-app-5` and `orch-other-app-5`).

The helper scripts use `tmux list-sessions | grep -E "^orch-.*-${TASK_ID}$"` to find sessions by task ID suffix — no project context required when calling `orch task attach <id>` or `orch task kill <id>`. `task_live.sh` uses `${name##*-}` to strip the variable-length project prefix.

## Test plan

- [x] Bash syntax check passes for all 4 modified files (`bash -n`)
- [x] No existing tests reference tmux session naming
- Manual: run two tasks from different projects with same issue number and verify no collision

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)