### PR TITLE
fix(lib): add 'hit your limit' to is_usage_limit_error() pattern

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -374,7 +374,7 @@ is_usage_limit_error() {
   # avoid false positives from generic network errors (e.g. 503 Service Unavailable,
   # SSH timeouts). "service overloaded" is Anthropic-specific. "service unavailable"
   # and bare "temporarily unavailable" are omitted — too common in unrelated errors.
-  printf '%s' "$text" | rg -qi '(?:\b429\b|too many requests|rate[ _-]?limit|usage[ _-]?limit|\bquota\b|insufficient[_ -]?quota|exceeded[_ -]?quota|limit (?:reached|exceeded)|overloaded[_ -]?error|service overloaded)'
+  printf '%s' "$text" | rg -qi '(?:\b429\b|too many requests|rate[ _-]?limit|usage[ _-]?limit|\bquota\b|insufficient[_ -]?quota|exceeded[_ -]?quota|limit (?:reached|exceeded|hit)|hit your limit|you.ve hit|overloaded[_ -]?error|service overloaded)'
 }
 
 # Redact common API key/token patterns before publishing text to GitHub comments.

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -1065,6 +1065,17 @@ SH
   [ "$status" -eq 0 ]
 }
 
+@test "is_usage_limit_error detects claude hit your limit message" {
+  run bash -c "source '${REPO_DIR}/scripts/lib.sh'; is_usage_limit_error \"You've hit your limit · resets 1pm\""
+  [ "$status" -eq 0 ]
+
+  run bash -c "source '${REPO_DIR}/scripts/lib.sh'; is_usage_limit_error 'hit your limit'"
+  [ "$status" -eq 0 ]
+
+  run bash -c "source '${REPO_DIR}/scripts/lib.sh'; is_usage_limit_error \"you've hit the limit\""
+  [ "$status" -eq 0 ]
+}
+
 @test "is_usage_limit_error does not match generic network errors" {
   # Plain "503 Service Unavailable" must NOT trigger a reroute — it is a generic
   # HTTP error unrelated to AI provider rate limits.


### PR DESCRIPTION
## Summary

Extend the regex in `is_usage_limit_error()` to detect Claude Max/Pro rate-limit messages that were causing tasks to fail permanently instead of gracefully rerouting to opencode.

## Problem

Claude's rate-limit message uses "You've hit your limit" which didn't match the existing pattern requiring `limit (?:reached|exceeded)`.

**Effect**: When Claude hits its hourly rate limit, the orchestrator misclassifies it as "invalid JSON response" and marks the task `needs_review` instead of rerouting to opencode. This caused tasks 324, 325 (and historically 287, 301) to permanently fail.

## Changes

- Added `limit (?:reached|exceeded|hit)` - now catches 'limit hit'
- Added `hit your limit` - catches standalone phrase  
- Added `you.ve hit` - catches "you've hit" with apostrophe variations
- Added test case for Claude's specific message format

## Testing

All usage limit error tests pass:
- `is_usage_limit_error matches rate limit patterns` ✓
- `is_usage_limit_error detects claude hit your limit message` ✓
- `is_usage_limit_error does not match generic network errors` ✓

Closes #336