### PR TITLE
docs(posts): evening retrospective 2026-02-25 — minimax routing failure

### DIFF
--- a/docs/content/posts/evening-retrospective-2026-02-25.md
+++ b/docs/content/posts/evening-retrospective-2026-02-25.md
@@ -1,0 +1,99 @@
++++
+title = "Evening Retrospective 2026-02-25"
+date = "2026-02-25"
++++
+
+## Evening Retrospective — 2026-02-25
+
+### Yesterday's Fixes Status
+
+| Issue | Status | Details |
+|-------|--------|---------|
+| **#332** dual scheduler | ✅ FIXED | Commit `98ebb1a` - skip global jobs_tick when project-local jobs.yml exists |
+| **#333** code-review agent | ✅ FIXED | Both `jobs.yml` files now have `agent: null` (router decides) |
+
+---
+
+### Today's Summary
+
+**Service Status:** Running v0.56.5, polling every ~45s, 2 projects (orchestrator, orch)
+
+**What Went Wrong:**
+
+1. **Task #341 failed (minimax agent)** - The evening retrospective task was assigned to `minimax` via round_robin routing. The agent started but produced no output - no JSON file, no commits, no response. The task was marked `needs_review` after ~1 minute.
+
+2. **Morning review job didn't fire** - The `morning-review` job (schedule: `0 10 * * *` = 10:00 UTC) did not create a task today. Last run was `2026-02-24T11:47:47Z`. The orchestrator service was running (PID 58679), so this is a bug.
+
+3. **Evening retrospective ran at wrong time** - Instead of running at 21:00 UTC, it ran at 00:00:22 UTC as a "catch-up" from a missed run. The schedule shows `0 21 * * *` but it seems the catch-up logic is firing incorrectly.
+
+---
+
+### Root Cause Analysis
+
+**minimax agent failure:**
+
+The round_robin routing is cycling through 5 agents:
+```
+(claude, codex, opencode, kimi, minimax) → task_id % 5
+341 % 5 = 1 → minimax
+```
+
+The problem: `route.md` doesn't mention `kimi` or `minimax` as executors - they're Claude Code aliases that weren't in the original prompt. When routed to these agents:
+- The CLI runs (`minimax -p ...`)
+- But no output JSON is produced
+- The task gets stuck "in_progress without agent" → `needs_review`
+
+**Morning job didn't fire:**
+
+Looking at the jobs.yml:
+- `morning-review`: schedule `0 10 * * *`, last_run `2026-02-24T11:47:47Z`
+- Service was running but no morning task was created
+
+This suggests either:
+1. The catch-up logic isn't working for morning jobs
+2. There's a timezone/schedule parsing issue
+
+---
+
+### Prompt Review
+
+`prompts/route.md` lines 6-9 only mention 3 executors:
+```
+- claude: best for...
+- codex: best for...
+- opencode: lightweight agent with access to multiple model providers (GitHub Copilot, Kimi, MiniMax)
+```
+
+**Missing:** `kimi` and `minimax` are not listed as executors, but round_robin routes to them.
+
+---
+
+### Issues to File
+
+| Priority | Issue | Description |
+|----------|-------|-------------|
+| 🔴 HIGH | **#334** | fix(route): add kimi and minimax to round_robin executor list OR exclude them from cycling |
+| 🟡 MEDIUM | **#335** | fix(jobs): morning-review job not firing at scheduled time (10:00 UTC) |
+| 🟡 MEDIUM | **#336** | fix(jobs): evening-retrospective running at wrong time (midnight instead of 21:00) |
+
+---
+
+### Tomorrow's Morning Priorities
+
+1. **Fix #334** - Either update `route.md` to include kimi/minimax as valid executors with proper descriptions, OR exclude them from round_robin cycling (they're just Claude Code aliases)
+
+2. **Investigate #335** - Why morning-review didn't fire. Check `jobs_tick.sh` for schedule matching issues.
+
+3. **Unblock task #341** - Manually retry the evening retrospective with a different agent (claude or codex)
+
+4. **Consider**: Should round_robin only cycle through proven agents (claude, codex, opencode) and exclude the newer aliases?
+
+---
+
+### Files Changed Today
+
+- None (task #341 failed to produce output)
+
+### Agent Activity
+
+- minimax: 1 attempt, 0 output, failed instantly


### PR DESCRIPTION
## Summary
- Document task #341 failure (minimax agent produced no output)
- Document morning-review job not firing at scheduled time
- File issues #342 (route kimi/minimax) and #343 (morning job)

## Test plan
- [ ] Review evening retrospective post for accuracy
- [ ] Verify issues #342 and #343 are properly categorized

🤖 Generated with [Claude Code](https://claude.com/claude-code)