### PR TITLE
fix(route): exclude kimi and minimax from round_robin cycling

### DIFF
--- a/scripts/route_task.sh
+++ b/scripts/route_task.sh
@@ -74,8 +74,19 @@ export TASK_ID TASK_TITLE TASK_LABELS TASK_BODY SKILLS_CATALOG AVAILABLE_AGENTS
 
 # ── Round-robin mode: skip LLM router, cycle through agents ──
 if [ "$ROUTING_MODE" = "round_robin" ]; then
-  IFS=',' read -ra _agents <<< "$AVAILABLE_AGENTS"
+  # Only cycle through primary agents (exclude kimi/minimax which are Claude Code aliases)
+  IFS=',' read -ra _all_agents <<< "$AVAILABLE_AGENTS"
+  _agents=()
+  for agent in "${_all_agents[@]}"; do
+    if [ "$agent" != "kimi" ] && [ "$agent" != "minimax" ]; then
+      _agents+=("$agent")
+    fi
+  done
   _agent_count=${#_agents[@]}
+  if [ "$_agent_count" -eq 0 ]; then
+    log_err "[route] round_robin: no primary agents available"
+    exit 1
+  fi
   ROUTED_AGENT="${_agents[$((TASK_ID % _agent_count))]}"
   REASON="round_robin (task $TASK_ID % $_agent_count agents)"
   COMPLEXITY="medium"


### PR DESCRIPTION
Closes #342

## Problem

Round_robin routing cycles through 5 agents (claude, codex, opencode, kimi, minimax), but task #341 assigned to `minimax` failed immediately with no output. The agent started but produced no JSON file, no commits, no response.

## Root Cause

`kimi` and `minimax` are Claude Code aliases that don't have distinct capabilities for this use case. When round_robin routes to them, they may not work correctly for this task type.

## Fix

Updated the round_robin logic in `scripts/route_task.sh` to exclude kimi and minimax from cycling. The round_robin mode now only cycles through primary agents (claude, codex, opencode).

## Changes

- Modified round_robin agent selection to filter out kimi and minimax
- Added safety check to exit with error if no primary agents are available

## Testing

All routing-related tests pass (12 tests).