### PR TITLE
fix(security): validate job commands before execution

### DIFF
--- a/scripts/jobs_tick.sh
+++ b/scripts/jobs_tick.sh
@@ -93,6 +93,17 @@ for JOB_ID in $JOB_IDS; do
       continue
     fi
 
+    # Validate command to prevent command injection attacks
+    if ! validate_job_command "$JOB_CMD"; then
+      job_log "[jobs] job=$JOB_ID command rejected: contains unsafe shell metacharacters"
+      job_log "[jobs] job=$JOB_ID disabling job to prevent security issue"
+      NOW=$(now_iso)
+      db_job_set "$JOB_ID" "enabled" "false"
+      db_job_set "$JOB_ID" "last_run" "$NOW"
+      db_job_set "$JOB_ID" "last_task_status" "failed"
+      continue
+    fi
+
     if [ -n "$JOB_DIR" ] && [ "$JOB_DIR" != "null" ] && [ ! -d "$JOB_DIR" ]; then
       job_log "[jobs] job=$JOB_ID invalid dir=$JOB_DIR, disabling job to prevent repeated failures"
       NOW=$(now_iso)

--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -344,6 +344,34 @@ require_agent() {
   fi
 }
 
+# Validate a bash job command to prevent command injection attacks.
+# Rejects commands containing shell metacharacters that could enable arbitrary code execution.
+# Returns 0 if command is safe, 1 if it contains dangerous characters.
+validate_job_command() {
+  local cmd="${1:-}"
+  [ -n "$cmd" ] || return 1
+
+  # Check for dangerous shell metacharacters
+  # These characters can be used to chain commands, redirect output, or spawn subshells
+  # Use fixed string matching for special chars that break regex: $ ( ) ` |
+  printf '%s' "$cmd" | rg -q -F ';' && return 1
+  printf '%s' "$cmd" | rg -q -F '&&' && return 1
+  printf '%s' "$cmd" | rg -q -F '||' && return 1
+  printf '%s' "$cmd" | rg -q -F '`' && return 1
+  printf '%s' "$cmd" | rg -q -F '$(' && return 1
+  printf '%s' "$cmd" | rg -q -F ')' && return 1
+  printf '%s' "$cmd" | rg -q -F '|' && return 1
+  printf '%s' "$cmd" | rg -q -F '{' && return 1
+  printf '%s' "$cmd" | rg -q -F '}' && return 1
+  printf '%s' "$cmd" | rg -q -F '[' && return 1
+  printf '%s' "$cmd" | rg -q -F ']' && return 1
+  printf '%s' "$cmd" | rg -q -F '!' && return 1
+  printf '%s' "$cmd" | rg -q -F '<' && return 1
+  printf '%s' "$cmd" | rg -q -F '>' && return 1
+
+  return 0
+}
+
 available_agents() {
   local agents=""
   local disabled=""

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -3097,6 +3097,67 @@ JSON
   [ "$output" = "failed" ]
 }
 
+# --- validate_job_command security tests ---
+
+@test "validate_job_command accepts safe commands" {
+  bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo hello'" 2>/dev/null
+  [ "$?" -eq 0 ]
+
+  bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'curl -s https://example.com'" 2>/dev/null
+  [ "$?" -eq 0 ]
+
+  bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'npm run build'" 2>/dev/null
+  [ "$?" -eq 0 ]
+}
+
+@test "validate_job_command rejects command injection" {
+  # Semicolon - command chaining
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo test; rm -rf /'" 2>/dev/null
+
+  # Pipe
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo test | cat'" 2>/dev/null
+
+  # Logical AND
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo test && rm -rf /'" 2>/dev/null
+
+  # Logical OR
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo test || rm -rf /'" 2>/dev/null
+
+  # Backticks
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command '\`ls\`'" 2>/dev/null
+
+  # Command substitution $()
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command '\$(ls)'" 2>/dev/null
+
+  # Redirection
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo test > /tmp/out'" 2>/dev/null
+
+  # Double quotes
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command 'echo \"test\"'" 2>/dev/null
+
+  # Single quotes (some contexts)
+  ! bash -c "source '${REPO_DIR}/scripts/lib.sh' && validate_job_command \"echo '\${VAR}'\"" 2>/dev/null
+}
+
+@test "jobs_tick.sh rejects bash job with shell metacharacters" {
+  export JOBS_PATH="${TMP_DIR}/jobs.yml"
+  echo '[]' > "$JOBS_FILE"
+
+  # Create bash job with command injection attempt
+  "${REPO_DIR}/scripts/jobs_add.sh" --type bash --command "echo test; rm -rf /" "* * * * *" "Bad Cmd Job" >/dev/null
+
+  run "${REPO_DIR}/scripts/jobs_tick.sh"
+  [ "$status" -eq 0 ]
+
+  # Job should be disabled due to unsafe command
+  run tdb_job_field "bad-cmd-job" enabled
+  [ "$output" = "false" ]
+
+  # Job should be marked as failed
+  run tdb_job_field "bad-cmd-job" last_task_status
+  [ "$output" = "failed" ]
+}
+
 @test "jobs_tick.sh disables bash job when dir is missing" {
   printf 'jobs: []\n' > "$JOBS_FILE"
 


### PR DESCRIPTION
## Summary
- Added `validate_job_command()` function in `scripts/lib.sh` to detect shell metacharacters that enable command injection
- Modified `scripts/jobs_tick.sh` to validate bash job commands before execution
- Jobs with unsafe commands are automatically disabled and marked as failed
- Added comprehensive tests for the validation function and job rejection

## Test plan
- [x] Run `bats tests/orchestrator.bats -f "validate_job_command"` - all pass
- [x] Run `bats tests/orchestrator.bats -f "jobs_tick.sh rejects bash job"` - passes
- [x] Run `bats tests/orchestrator.bats -f "jobs_tick.sh"` - all 12 tests pass

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)