### PR TITLE
fix(review): handle reject decision in review_prs.sh — close PR on reject

### DIFF
--- a/scripts/review_prs.sh
+++ b/scripts/review_prs.sh
@@ -224,11 +224,12 @@ _review_pr() {
   # Build comment body
   local BADGE ICON COMMENT_BODY
   BADGE=$(_review_badge "$REVIEW_AGENT")
-  if [ "$DECISION" = "approve" ]; then
-    ICON="approve"
-  else
-    ICON="request_changes"
-  fi
+  case "$DECISION" in
+    approve)          ICON="approve" ;;
+    reject)           ICON="request_changes" ;;
+    request_changes)  ICON="request_changes" ;;
+    *)                ICON="request_changes" ;;
+  esac
 
   COMMENT_BODY=$(cat <<EOF
 ## ${BADGE} Automated Review — $([ "$ICON" = "approve" ] && echo "Approve" || echo "Changes Requested")
@@ -249,6 +250,13 @@ EOF
     gh pr review "$pr_number" --repo "$REPO" --request-changes --body "$COMMENT_BODY" 2>/dev/null \
       || gh pr comment "$pr_number" --repo "$REPO" --body "$COMMENT_BODY" 2>/dev/null \
       || log_err "[review_prs] failed to post review on PR #$pr_number"
+  fi
+
+  # Close PR on reject
+  if [ "$DECISION" = "reject" ]; then
+    gh pr close "$pr_number" --repo "$REPO" --comment "Review rejected: $NOTES" 2>/dev/null \
+      || log_err "[review_prs] failed to close PR #$pr_number on reject"
+    log "[review_prs] [$PROJECT_NAME] PR #$pr_number: closed (reject)"
   fi
 
   # Record in state

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -4820,6 +4820,61 @@ SH
   [[ "$output" == *"request_changes"* ]]
 }
 
+@test "review_prs.sh reject decision closes PR" {
+  run yq -i '.workflow.enable_review_agent = true' "$CONFIG_PATH"
+  run yq -i '.workflow.review_agent = "claude"' "$CONFIG_PATH"
+  run yq -i '.gh.repo = "owner/repo"' "$CONFIG_PATH"
+  [ "$status" -eq 0 ]
+
+  GH_STUB="${TMP_DIR}/gh"
+  CLOSED_FILE="${TMP_DIR}/closed_prs.txt"
+  cat > "$GH_STUB" <<SH
+#!/usr/bin/env bash
+if [ "\$1" = "api" ] && [[ "\$*" == *"repos/owner/repo/pulls"* ]] && [[ "\$*" != *"issues"* ]]; then
+  echo '[{"number":7,"title":"Bad PR","body":"","user":{"login":"dev"},"head":{"sha":"bad123","ref":"feat/bad"},"draft":false}]'
+  exit 0
+fi
+if [ "\$1" = "api" ] && [[ "\$*" == *"issues"* ]]; then
+  echo '[]'
+  exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "diff" ]; then
+  echo "+bad code"
+  exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "review" ]; then
+  exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "close" ]; then
+  echo "closed" >> "${CLOSED_FILE}"
+  exit 0
+fi
+if [ "\$1" = "pr" ] && [ "\$2" = "comment" ]; then
+  exit 0
+fi
+exit 0
+SH
+  chmod +x "$GH_STUB"
+
+  CLAUDE_STUB="${TMP_DIR}/claude"
+  cat > "$CLAUDE_STUB" <<'SH'
+#!/usr/bin/env bash
+echo '{"decision":"reject","notes":"Hallucinated API calls, does not compile."}'
+SH
+  chmod +x "$CLAUDE_STUB"
+
+  run env PATH="${TMP_DIR}:${PATH}" AGENT_TIMEOUT_SECONDS=10 "${REPO_DIR}/scripts/review_prs.sh"
+  [ "$status" -eq 0 ]
+
+  # PR should have been closed
+  [ -f "$CLOSED_FILE" ]
+
+  # State should record the reject decision
+  run grep "7" "${STATE_DIR}/pr_reviews_owner_repo.tsv"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"reject"* ]]
+}
+
 @test "review_prs.sh handles merge command from owner" {
   run yq -i '.workflow.enable_review_agent = true' "$CONFIG_PATH"
   run yq -i '.workflow.review_owner = "gabriel"' "$CONFIG_PATH"


### PR DESCRIPTION
## Summary

- `review_prs.sh` silently treated `reject` as `request_changes` because the if/else only handled `approve` explicitly
- Added explicit `reject` handling: closes the PR via `gh pr close` with a comment containing the review notes
- Updated ICON logic from if/else to `case` statement (approve/reject/request_changes/*)
- Added bats test verifying `gh pr close` is called when decision is `reject`

## Root cause

`review_prs.sh` wasn't updated when the `reject` decision was added to `prompts/review.md`. The two review paths (`run_task.sh` inline vs `review_prs.sh` standalone) diverged.

## Test plan
- [x] All 10 `review_prs.sh` bats tests pass
- [x] New test: `review_prs.sh reject decision closes PR`

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)