### PR TITLE
fix: fail explicitly when no timeout utility available in run_with_timeout

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -1389,5 +1389,6 @@ except subprocess.TimeoutExpired:
 PY
     return $?
   fi
-  "$@"
+  echo "Error: No timeout utility available (timeout, gtimeout, or python3 required)" >&2
+  return 2
 }

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -5769,3 +5769,32 @@ YAML
   [ "$status" -eq 0 ]
   [ "$output" = "${ORCH_HOME}/jobs.yml" ]
 }
+
+@test "run_with_timeout fails with exit 2 when no timeout utility available" {
+  run bash -c "
+    source '${REPO_DIR}/scripts/lib.sh'
+    export AGENT_TIMEOUT_SECONDS=10
+    # Override 'command' to hide timeout/gtimeout/python3 from 'command -v'
+    command() {
+      if [ \"\$1\" = '-v' ]; then
+        case \"\$2\" in
+          timeout|gtimeout|python3) return 1 ;;
+        esac
+      fi
+      builtin command \"\$@\"
+    }
+    run_with_timeout echo hello
+  "
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"No timeout utility available"* ]]
+}
+
+@test "run_with_timeout runs command directly when timeout is 0" {
+  run bash -c "
+    source '${REPO_DIR}/scripts/lib.sh'
+    export AGENT_TIMEOUT_SECONDS=0
+    run_with_timeout echo hello
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello"* ]]
+}


### PR DESCRIPTION
## Summary
- Replace silent fallback (running command without timeout) with explicit error + return code 2
- When none of `timeout`, `gtimeout`, or `python3` are available, the function now fails instead of silently running without timeout protection
- Added 2 tests: no-utility error case and timeout=0 bypass case

Closes #365

## Test plan
- [x] `run_with_timeout` returns exit code 2 and error message when no timeout utility found
- [x] `run_with_timeout` still runs command directly when `AGENT_TIMEOUT_SECONDS=0`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)