### PR TITLE
Added quotes to local variable assignments in scripts/lib.sh gh_api function and other locations

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -146,9 +146,9 @@ gh_backoff_next_delay() {
 }
 
 gh_api() {
-  local mode=${GH_BACKOFF_MODE:-wait}
-  local base=${GH_BACKOFF_BASE_SECONDS:-30}
-  local max=${GH_BACKOFF_MAX_SECONDS:-900}
+  local mode="${GH_BACKOFF_MODE:-wait}"
+  local base="${GH_BACKOFF_BASE_SECONDS:-30}"
+  local max="${GH_BACKOFF_MAX_SECONDS:-900}"
   local errexit_enabled=0
   if [[ $- == *e* ]]; then
     errexit_enabled=1
@@ -650,7 +650,7 @@ lock_mtime() {
 
 lock_is_stale() {
   local path="$1"
-  local stale_seconds=${LOCK_STALE_SECONDS:-600}
+  local stale_seconds="${LOCK_STALE_SECONDS:-600}"
   local mtime
   mtime=$(lock_mtime "$path")
   if [ -z "$mtime" ] || [ "$mtime" -eq 0 ] 2>/dev/null; then
@@ -701,8 +701,8 @@ append_task_context() {
 
 retry_delay_seconds() {
   local attempts=$1
-  local base=${RETRY_BASE_SECONDS:-60}
-  local max=${RETRY_MAX_SECONDS:-3600}
+  local base="${RETRY_BASE_SECONDS:-60}"
+  local max="${RETRY_MAX_SECONDS:-3600}"
   local exp=$((attempts - 1))
   local delay=$base
   if [ "$exp" -gt 0 ]; then
@@ -1375,7 +1375,7 @@ process_owner_feedback() {
 }
 
 run_with_timeout() {
-  local timeout_seconds=${AGENT_TIMEOUT_SECONDS:-1800}
+  local timeout_seconds="${AGENT_TIMEOUT_SECONDS:-1800}"
   if [ -z "$timeout_seconds" ] || [ "$timeout_seconds" = "0" ]; then
     "$@"
     return $?


### PR DESCRIPTION
## Summary

Added quotes to local variable assignments in scripts/lib.sh gh_api function and other locations

### What was done

- Fixed unquoted local variable assignments in gh_api() function (lines 149-151)
- Added quotes around ${GH_BACKOFF_MODE:-wait}
- Added quotes around ${GH_BACKOFF_BASE_SECONDS:-30}
- Added quotes around ${GH_BACKOFF_MAX_SECONDS:-900}
- Also fixed similar patterns in lock_is_stale(), retry_delay_seconds(), and run_with_timeout() functions
- Committed changes with conventional commit message: 'fix(lib): add quotes to local variable assignments in gh_backoff function'

### Remaining

- Push branch to remote: git push -u origin gh-task-378-fix-add-quotes-to-local-variable-assignm
- Create PR: gh pr create --base main --head gh-task-378-fix-add-quotes-to-local-variable-assignm --title 'fix(lib): add quotes to local variable assignments in gh_backoff function' --body 'Closes #378'
- Post completion comment on GitHub issue #378

### Files changed

- `scripts/lib.sh`

Closes #378

---
*Created by kimi[bot] via [Orchestrator](https://github.com/gabrielkoerich/orchestrator)*