### PR TITLE
fix(backend): remove duplicate TASK_GH_STATE export in db_load_task

### DIFF
--- a/scripts/backend_github.sh
+++ b/scripts/backend_github.sh
@@ -862,7 +862,6 @@ db_load_task() {
   export TASK_LAST_ERROR=$(printf '%s' "$sc" | jq -r '.last_error // empty')
   export TASK_PROMPT_HASH=$(printf '%s' "$sc" | jq -r '.prompt_hash // empty')
   export TASK_GH_SYNCED_AT=$(printf '%s' "$sc" | jq -r '.gh_synced_at // empty')
-  export TASK_GH_STATE=$(printf '%s' "$json" | jq -r '.state // empty')
   export TASK_GH_UPDATED_AT=$(printf '%s' "$json" | jq -r '.updated_at // empty')
   export TASK_GH_LAST_FEEDBACK_AT=$(printf '%s' "$sc" | jq -r '.gh_last_feedback_at // empty')
   export TASK_GH_PROJECT_ITEM_ID=$(printf '%s' "$sc" | jq -r '.gh_project_item_id // empty')


### PR DESCRIPTION
## Summary
- Removed duplicate `TASK_GH_STATE` export at line 865 in `scripts/backend_github.sh`
- The duplicate was overwriting the correct value from line 846 (which reads from GitHub API response)
- This was likely a copy-paste error when adding sidecar field loading logic

Closes #391

## Test plan
- [x] Verify bash syntax is valid
- [x] Confirm only one `TASK_GH_STATE` export remains (line 846)

🤖 Generated with [Claude Code](https://claude.com/claude-code)