### PR TITLE
fix(run_task): move _gh_ensure_repo out of subshell in detect_retry_loop

### DIFF
--- a/scripts/run_task.sh
+++ b/scripts/run_task.sh
@@ -360,8 +360,10 @@ detect_retry_loop() {
   fi
 
   # Strip timestamp prefix (e.g. "[2026-01-01T00:00:00Z] ") before comparing for uniqueness
+  # Call _gh_ensure_repo in parent shell so _GH_REPO side effect is preserved
+  _gh_ensure_repo 2>/dev/null || true
   local _COMMENTS_JSON
-  _COMMENTS_JSON=$(gh_api -X GET "repos/$(_gh_ensure_repo 2>/dev/null; echo "$_GH_REPO")/issues/$task_id/comments" -f per_page=100 2>/dev/null || echo '[]')
+  _COMMENTS_JSON=$(gh_api -X GET "repos/$_GH_REPO/issues/$task_id/comments" -f per_page=100 2>/dev/null || echo '[]')
   local BLOCKED_NOTES
   BLOCKED_NOTES=$(printf '%s' "$_COMMENTS_JSON" \
     | jq -r '[.[] | select(.body | test("blocked:"; "i"))] | .[-3:] | [.[] | (.body | sub("^\\[\\d{4}-[^]]+\\] "; ""))] | unique | length' 2>/dev/null || echo "0")


### PR DESCRIPTION
## Summary
- Move `_gh_ensure_repo` call out of command substitution `$(...)` in `detect_retry_loop()` so its side effect (setting `_GH_REPO`) is preserved in the parent shell
- Use `$_GH_REPO` directly in the subsequent `gh_api` call instead of calling `_gh_ensure_repo` inside the subshell

## Root Cause
`_gh_ensure_repo` sets the global `_GH_REPO` variable, but when called inside command substitution, changes to variables are lost when the subshell exits. This could cause retry loop detection to fail by using an unset or stale repository path.

## Test plan
- [x] `bats tests/orchestrator.bats --filter "retry loop"` — both retry loop tests pass
- [x] `bash -n scripts/run_task.sh` — syntax check passes
- [x] Verified no other instances of `_gh_ensure_repo` inside `$(...)` in the codebase

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)