### PR TITLE
fix: add error handling for empty/missing PR title in create-pr.sh

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -10,8 +10,18 @@ if [ ! -f .orchestrator/pr-title.txt ] || [ ! -f .orchestrator/pr-body.md ]; the
   scripts/make-pr-body.sh "$BASE_BRANCH" >/dev/null
 fi
 
+if [ ! -f .orchestrator/pr-title.txt ]; then
+  echo "Error: .orchestrator/pr-title.txt not found" >&2
+  exit 1
+fi
+
 BRANCH=$(git branch --show-current)
 TITLE=$(cat .orchestrator/pr-title.txt)
+
+if [ -z "$TITLE" ]; then
+  echo "Error: PR title is empty. Ensure you have commits on the branch." >&2
+  exit 1
+fi
 
 if gh pr view "$BRANCH" --json url --jq .url >/dev/null 2>&1; then
   gh pr view "$BRANCH" --json url --jq .url


### PR DESCRIPTION
- Check if .orchestrator/pr-title.txt exists before reading
- Validate that TITLE is not empty before creating PR
- Exit with descriptive error messages if validation fails
