### PR TITLE
fix(backend): return 1 for invalid IDs in db_task_field

### DIFF
--- a/scripts/backend_github.sh
+++ b/scripts/backend_github.sh
@@ -382,7 +382,7 @@ db_task_field() {
 
   # GitHub issues are always numeric
   if ! [[ "$id" =~ ^[0-9]+$ ]]; then
-    return 0
+    return 1
   fi
 
   # Check sidecar first for ephemeral fields


### PR DESCRIPTION
## Summary

- `db_task_field` returned 0 (success) for non-numeric IDs, silently passing invalid input as valid
- Changed `return 0` to `return 1` so callers can detect and handle invalid IDs properly

## Test plan

- [x] All 296 existing tests pass
- [x] Verified the one-line change in `scripts/backend_github.sh:385`

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)