### PR TITLE
fix: validate PR title and make-pr-body.sh exit status in create-pr.sh

### DIFF
--- a/scripts/create-pr.sh
+++ b/scripts/create-pr.sh
@@ -7,11 +7,29 @@ ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 cd "$ROOT_DIR"
 
 if [ ! -f .orchestrator/pr-title.txt ] || [ ! -f .orchestrator/pr-body.md ]; then
-  scripts/make-pr-body.sh "$BASE_BRANCH" >/dev/null
+  if ! scripts/make-pr-body.sh "$BASE_BRANCH" >/dev/null; then
+    echo "Error: make-pr-body.sh failed" >&2
+    exit 1
+  fi
+fi
+
+if [ ! -f .orchestrator/pr-title.txt ]; then
+  echo "Error: .orchestrator/pr-title.txt not found after running make-pr-body.sh" >&2
+  exit 1
+fi
+
+if [ ! -f .orchestrator/pr-body.md ]; then
+  echo "Error: .orchestrator/pr-body.md not found after running make-pr-body.sh" >&2
+  exit 1
 fi
 
 BRANCH=$(git branch --show-current)
 TITLE=$(cat .orchestrator/pr-title.txt)
+
+if [ -z "${TITLE// /}" ]; then
+  echo "Error: PR title is empty in .orchestrator/pr-title.txt" >&2
+  exit 1
+fi
 
 if gh pr view "$BRANCH" --json url --jq .url >/dev/null 2>&1; then
   gh pr view "$BRANCH" --json url --jq .url

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -5883,3 +5883,65 @@ YAML
   [ "$status" -eq 0 ]
   [[ "$output" == *"hello"* ]]
 }
+
+# --- create-pr.sh validation tests ---
+
+@test "create-pr.sh fails when make-pr-body.sh fails" {
+  # Stub make-pr-body.sh to fail
+  STUB="${PROJECT_DIR}/scripts/make-pr-body.sh"
+  mkdir -p "$(dirname "$STUB")"
+  cat > "$STUB" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+  chmod +x "$STUB"
+
+  # Ensure pr-title.txt does not exist so make-pr-body.sh is invoked
+  rm -f "${PROJECT_DIR}/.orchestrator/pr-title.txt"
+  rm -f "${PROJECT_DIR}/.orchestrator/pr-body.md"
+
+  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"make-pr-body.sh failed"* ]]
+}
+
+@test "create-pr.sh fails when pr-title.txt is empty" {
+  mkdir -p "${PROJECT_DIR}/.orchestrator"
+  printf '' > "${PROJECT_DIR}/.orchestrator/pr-title.txt"
+  printf '## Summary\ntest\n' > "${PROJECT_DIR}/.orchestrator/pr-body.md"
+
+  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"PR title is empty"* ]]
+}
+
+@test "create-pr.sh fails when pr-title.txt is whitespace-only" {
+  mkdir -p "${PROJECT_DIR}/.orchestrator"
+  printf '   \n' > "${PROJECT_DIR}/.orchestrator/pr-title.txt"
+  printf '## Summary\ntest\n' > "${PROJECT_DIR}/.orchestrator/pr-body.md"
+
+  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"PR title is empty"* ]]
+}
+
+@test "create-pr.sh fails when pr-body.md is missing after make-pr-body.sh" {
+  # Stub make-pr-body.sh to only create title, not body
+  STUB="${PROJECT_DIR}/scripts/make-pr-body.sh"
+  mkdir -p "$(dirname "$STUB")"
+  cat > "$STUB" <<'STUB'
+#!/usr/bin/env bash
+mkdir -p .orchestrator
+echo "Some title" > .orchestrator/pr-title.txt
+# Intentionally skip creating pr-body.md
+STUB
+  chmod +x "$STUB"
+
+  # Ensure neither file exists so make-pr-body.sh is invoked
+  rm -f "${PROJECT_DIR}/.orchestrator/pr-title.txt"
+  rm -f "${PROJECT_DIR}/.orchestrator/pr-body.md"
+
+  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"pr-body.md not found"* ]]
+}

--- a/tests/orchestrator.bats
+++ b/tests/orchestrator.bats
@@ -5887,61 +5887,67 @@ YAML
 # --- create-pr.sh validation tests ---
 
 @test "create-pr.sh fails when make-pr-body.sh fails" {
+  # Copy create-pr.sh into PROJECT_DIR so ROOT_DIR resolves correctly
+  mkdir -p "${PROJECT_DIR}/scripts"
+  cp "${REPO_DIR}/scripts/create-pr.sh" "${PROJECT_DIR}/scripts/create-pr.sh"
+
   # Stub make-pr-body.sh to fail
-  STUB="${PROJECT_DIR}/scripts/make-pr-body.sh"
-  mkdir -p "$(dirname "$STUB")"
-  cat > "$STUB" <<'STUB'
+  cat > "${PROJECT_DIR}/scripts/make-pr-body.sh" <<'STUB'
 #!/usr/bin/env bash
 exit 1
 STUB
-  chmod +x "$STUB"
+  chmod +x "${PROJECT_DIR}/scripts/make-pr-body.sh"
 
   # Ensure pr-title.txt does not exist so make-pr-body.sh is invoked
   rm -f "${PROJECT_DIR}/.orchestrator/pr-title.txt"
   rm -f "${PROJECT_DIR}/.orchestrator/pr-body.md"
 
-  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  run bash -c "cd '$PROJECT_DIR' && '${PROJECT_DIR}/scripts/create-pr.sh' main"
   [ "$status" -ne 0 ]
   [[ "$output" == *"make-pr-body.sh failed"* ]]
 }
 
 @test "create-pr.sh fails when pr-title.txt is empty" {
-  mkdir -p "${PROJECT_DIR}/.orchestrator"
+  mkdir -p "${PROJECT_DIR}/scripts" "${PROJECT_DIR}/.orchestrator"
+  cp "${REPO_DIR}/scripts/create-pr.sh" "${PROJECT_DIR}/scripts/create-pr.sh"
   printf '' > "${PROJECT_DIR}/.orchestrator/pr-title.txt"
   printf '## Summary\ntest\n' > "${PROJECT_DIR}/.orchestrator/pr-body.md"
 
-  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  run bash -c "cd '$PROJECT_DIR' && '${PROJECT_DIR}/scripts/create-pr.sh' main"
   [ "$status" -ne 0 ]
   [[ "$output" == *"PR title is empty"* ]]
 }
 
 @test "create-pr.sh fails when pr-title.txt is whitespace-only" {
-  mkdir -p "${PROJECT_DIR}/.orchestrator"
+  mkdir -p "${PROJECT_DIR}/scripts" "${PROJECT_DIR}/.orchestrator"
+  cp "${REPO_DIR}/scripts/create-pr.sh" "${PROJECT_DIR}/scripts/create-pr.sh"
   printf '   \n' > "${PROJECT_DIR}/.orchestrator/pr-title.txt"
   printf '## Summary\ntest\n' > "${PROJECT_DIR}/.orchestrator/pr-body.md"
 
-  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  run bash -c "cd '$PROJECT_DIR' && '${PROJECT_DIR}/scripts/create-pr.sh' main"
   [ "$status" -ne 0 ]
   [[ "$output" == *"PR title is empty"* ]]
 }
 
 @test "create-pr.sh fails when pr-body.md is missing after make-pr-body.sh" {
+  # Copy create-pr.sh into PROJECT_DIR so ROOT_DIR resolves correctly
+  mkdir -p "${PROJECT_DIR}/scripts"
+  cp "${REPO_DIR}/scripts/create-pr.sh" "${PROJECT_DIR}/scripts/create-pr.sh"
+
   # Stub make-pr-body.sh to only create title, not body
-  STUB="${PROJECT_DIR}/scripts/make-pr-body.sh"
-  mkdir -p "$(dirname "$STUB")"
-  cat > "$STUB" <<'STUB'
+  cat > "${PROJECT_DIR}/scripts/make-pr-body.sh" <<'STUB'
 #!/usr/bin/env bash
 mkdir -p .orchestrator
 echo "Some title" > .orchestrator/pr-title.txt
 # Intentionally skip creating pr-body.md
 STUB
-  chmod +x "$STUB"
+  chmod +x "${PROJECT_DIR}/scripts/make-pr-body.sh"
 
   # Ensure neither file exists so make-pr-body.sh is invoked
   rm -f "${PROJECT_DIR}/.orchestrator/pr-title.txt"
   rm -f "${PROJECT_DIR}/.orchestrator/pr-body.md"
 
-  run bash -c "cd '$PROJECT_DIR' && '${REPO_DIR}/scripts/create-pr.sh' main"
+  run bash -c "cd '$PROJECT_DIR' && '${PROJECT_DIR}/scripts/create-pr.sh' main"
   [ "$status" -ne 0 ]
   [[ "$output" == *"pr-body.md not found"* ]]
 }


### PR DESCRIPTION
## Summary
- Validate `make-pr-body.sh` exit status before proceeding
- Check that `pr-title.txt` and `pr-body.md` exist after generation
- Reject empty or whitespace-only PR titles with clear error messages

## Test plan
- [x] Test: `create-pr.sh` fails when `make-pr-body.sh` exits non-zero
- [x] Test: `create-pr.sh` fails when `pr-title.txt` is empty
- [x] Test: `create-pr.sh` fails when `pr-title.txt` is whitespace-only
- [x] Test: `create-pr.sh` fails when `pr-body.md` is missing after generation

Closes #430

🤖 Generated with [Claude Code](https://claude.com/claude-code)